### PR TITLE
Pause logic and property

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ getPlayer(channel).then(player => {
 	}
 })
 ```
+
+**A note on pauses** 
+
+When you pause a player, the player will be kept in a paused state until you explicitly call resume or the player is disconnected. `player.paused` can be used to check if the player is in paused state.

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ getPlayer(channel).then(player => {
 
 **A note on pauses** 
 
-When you pause a player, the player will be kept in a paused state until you explicitly call resume or the player is disconnected. `player.paused` can be used to check if the player is in paused state.
+When you pause a player, the player will be kept in a paused state until you explicitly call resume or the player is disconnected. Calls to `play` and `stop` won't clear the pause state. `player.paused` can be used to check if the player is in paused state.

--- a/src/Player.js
+++ b/src/Player.js
@@ -40,6 +40,7 @@ class Player extends EventEmitter {
         this.options = options;
         this.ready = false;
         this.playing = false;
+        this.paused = false;
         this.shard = shard;
         this.state = {};
         this.track = null;
@@ -108,6 +109,7 @@ class Player extends EventEmitter {
      */
     async disconnect(msg) {
         this.playing = false;
+        this.paused = false;
         this.queueEvent({ op: 'disconnect', guildId: this.guildId });
         this.emit('disconnect', msg);
     }
@@ -134,7 +136,7 @@ class Player extends EventEmitter {
         }, options);
 
         this.queueEvent(payload);
-        this.playing = true;
+        this.playing = !this.paused;
         this.timestamp = Date.now();
     }
 
@@ -170,6 +172,7 @@ class Player extends EventEmitter {
     /**
      * Used to pause/resume the player
      * @param {boolean} pause Set pause to true/false
+     * @private
      */
     setPause(pause) {
         this.node.send({
@@ -177,6 +180,27 @@ class Player extends EventEmitter {
             guildId: this.guildId,
             pause: pause,
         });
+
+        this.paused = pause;
+        this.playing = !pause;
+    }
+
+    /**
+     * Used to pause the player
+     */
+    pause() {
+        if (this.playing) {
+            this.setPause(true);
+        }
+    }
+
+    /**
+     * Used to resume the player
+     */
+    resume() {
+        if (!this.playing && this.paused) {
+            this.setPause(false)
+        }
     }
 
     /**

--- a/src/Player.js
+++ b/src/Player.js
@@ -109,7 +109,13 @@ class Player extends EventEmitter {
      */
     async disconnect(msg) {
         this.playing = false;
-        this.paused = false;
+
+        // Player pause state will persist even after
+        // disconnecting
+        if (this.paused) {
+            this.resume()
+        }
+
         this.queueEvent({ op: 'disconnect', guildId: this.guildId });
         this.emit('disconnect', msg);
     }

--- a/src/PlayerManager.js
+++ b/src/PlayerManager.js
@@ -167,7 +167,7 @@ class PlayerManager extends Collection {
      * @param {boolean} leave Whether to leave the channel or not on our side
      */
     switchNode(player, leave) {
-        let { guildId, channelId, track } = player,
+        let { guildId, channelId, track, paused } = player,
             position = (player.state.position || 0) + (this.options.reconnectThreshold || 2000);
 
         let listeners = player.listeners('end'),
@@ -198,6 +198,9 @@ class PlayerManager extends Collection {
 
         process.nextTick(() => {
             this.join(guildId, channelId, null, player).then(player => {
+                if (paused) {
+                    player.pause();
+                }
                 player.play(track, { startTime: position });
                 player.emit('reconnect');
                 this.set(guildId, player);


### PR DESCRIPTION
Hey, This PR is meant to be a discussion about a possible implementation of a better pause state handling.

Main problem here is: Lavaplayer will keep the player paused even after we call `.leave`, so we need to keep that in mind and handle this behavior.

I put together this quick implementation so we can discuss if this will fuck something up. I haven't thought about all the code paths and possible disconnection reasons for a node, and I couldn't test lavaplayer's behaviour towards the pause state when an error occurs.

I've also added some logic to recover the node on a failover with the proper pause state.

Does this makes sense? Any considerations?

This PR contains code from #5, when it get's merged everything will be good.