### PR TITLE
Fix example in README - .leave() to .disconnect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ getPlayer(channel).then(player => {
 	player.stop();
 	if (leave) {
 		// disconnect and leave the channel
-		player.leave();
+		player.disconnect();
 	}
 })
 ```


### PR DESCRIPTION
Pretty much a farming PR, although this tends to confuse people when initially looking at the repo.