### PR TITLE
Remove options variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,6 @@ function getPlayer(channel) {
 		return Promise.resolve(player);
 	}
 
-	let options = {};
-	if (channel.guild.region) {
-		options.region = channel.guild.region;
-	}
-
 	return client.joinVoiceChannel(channel.id);
 }
 


### PR DESCRIPTION
This is a useless variable, and is not used anywhere within the example. I don't know why it's there in the first place.